### PR TITLE
Try using `peerDependencyRules.allowedVersions`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,13 @@
   "dependencies": {
     "react": "18",
     "react-dom": "18"
+  },
+  "pnpm": {
+    "peerDependencyRules": {
+      "allowedVersions": {
+        "react": "18",
+        "react-dom": "18"
+      }
+    }
   }
 }


### PR DESCRIPTION
Tried, with no luck. The problem persists. :x:

```
pnpm link ./linked_modules/@prezly/slate/packages/slate-types
.../@prezly/slate/packages/slate-types   |  WARN  Moving @types/node that was installed by a different package manager to "node_modules/.ignored"
.../@prezly/slate/packages/slate-types   |  WARN  Moving @prezly/uploads that was installed by a different package manager to "node_modules/.ignored"
.../@prezly/slate/packages/slate-types   |  WARN  Moving is-plain-object that was installed by a different package manager to "node_modules/.ignored"
.../@prezly/slate/packages/slate-types   |  +14 +
Packages are hard linked from the content-addressable store to the virtual store.
  Content-addressable store is at: /home/ivan/.local/share/pnpm/store/v3
  Virtual store is at:             linked_modules/@prezly/slate/packages/slate-types/node_modules/.pnpm

node_modules:
+ @prezly/slate-types 0.80.4 <- linked_modules/@prezly/slate/packages/slate-types

.../@prezly/slate/packages/slate-types   | Progress: resolved 14, reused 14, downloaded 0, added 14, done
pnpm link ./linked_modules/@prezly/slate/packages/slate-commons
.../@prezly/slate/packages/slate-commons |  WARN  Moving @types/node that was installed by a different package manager to "node_modules/.ignored"
.../@prezly/slate/packages/slate-commons |  +36 ++++
Packages are hard linked from the content-addressable store to the virtual store.
  Content-addressable store is at: /home/ivan/.local/share/pnpm/store/v3
  Virtual store is at:             linked_modules/@prezly/slate/packages/slate-commons/node_modules/.pnpm
 WARN  Issues with peer dependencies found
.
└─┬ react-dom 18.2.0
  └── ✕ unmet peer react@^18.2.0: found 16.9.0


node_modules:
+ @prezly/slate-commons 0.80.4 <- linked_modules/@prezly/slate/packages/slate-commons

.../@prezly/slate/packages/slate-commons | Progress: resolved 36, reused 36, downloaded 0, added 36, done

```