### PR TITLE
Try using `overrides`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,11 @@
   "dependencies": {
     "react": "18",
     "react-dom": "18"
+  },
+  "pnpm": {
+    "overrides": {
+      "react": "18",
+      "react-dom": "18"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+overrides:
+  react: '18'
+  react-dom: '18'
+
 dependencies:
   react:
     specifier: '18'


### PR DESCRIPTION
No luck. The problem persists. :x: 

```
pnpm link ./linked_modules/@prezly/slate/packages/slate-commons
.../@prezly/slate/packages/slate-commons |  WARN  Moving @types/node that was installed by a different package manager to "node_modules/.ignored"
.../@prezly/slate/packages/slate-commons |  +36 ++++
Packages are hard linked from the content-addressable store to the virtual store.
  Content-addressable store is at: /home/ivan/.local/share/pnpm/store/v3
  Virtual store is at:             linked_modules/@prezly/slate/packages/slate-commons/node_modules/.pnpm
 WARN  Issues with peer dependencies found
.
└─┬ react-dom 18.2.0
  └── ✕ unmet peer react@^18.2.0: found 16.9.0


node_modules:
+ @prezly/slate-commons 0.80.4 <- linked_modules/@prezly/slate/packages/slate-commons

.../@prezly/slate/packages/slate-commons | Progress: resolved 36, reused 36, downloaded 0, added 36, done

```