### PR TITLE
Try using patching linked package requirements before linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ linked_modules/@prezly/slate/build: linked_modules/@prezly/slate/node_modules
 
 linked_modules/@prezly/slate/node_modules: linked_modules/@prezly/slate
 	cd linked_modules/@prezly/slate && npm run bootstrap
+	# Patch linked module to explicitly react@18
+	cd linked_modules/@prezly/slate && npm add react@18 react-dom@18
+	cd linked_modules/@prezly/slate && npm rm react -w packages/slate-commons && npm add react@18 -w packages/slate-commons
 
 linked_modules/@prezly/slate: linked_modules/@prezly
 	git clone git@github.com:prezly/slate.git linked_modules/@prezly/slate


### PR DESCRIPTION
This seems to work, but in an absolutely ugly way. :heavy_check_mark: 

```
pnpm link ./linked_modules/@prezly/slate/packages/slate-types
.../@prezly/slate/packages/slate-types   |  WARN  Moving @types/node that was installed by a different package manager to "node_modules/.ignored"
.../@prezly/slate/packages/slate-types   |  WARN  Moving @prezly/uploads that was installed by a different package manager to "node_modules/.ignored"
.../@prezly/slate/packages/slate-types   |  WARN  Moving is-plain-object that was installed by a different package manager to "node_modules/.ignored"
.../@prezly/slate/packages/slate-types   |  +14 +
Packages are hard linked from the content-addressable store to the virtual store.
  Content-addressable store is at: /home/ivan/.local/share/pnpm/store/v3
  Virtual store is at:             linked_modules/@prezly/slate/packages/slate-types/node_modules/.pnpm
.../@prezly/slate/packages/slate-types   | Progress: resolved 14, reused 14, downloaded 0, added 14, done
pnpm link ./linked_modules/@prezly/slate/packages/slate-commons
.../@prezly/slate/packages/slate-commons |  WARN  Moving @types/node that was installed by a different package manager to "node_modules/.ignored"
.../@prezly/slate/packages/slate-commons |  +33 +++
Packages are hard linked from the content-addressable store to the virtual store.
  Content-addressable store is at: /home/ivan/.local/share/pnpm/store/v3
  Virtual store is at:             linked_modules/@prezly/slate/packages/slate-commons/node_modules/.pnpm
.../@prezly/slate/packages/slate-commons | Progress: resolved 33, reused 33, downloaded 0, added 33, done
```